### PR TITLE
Fix: Taking out long samples more stably.

### DIFF
--- a/entity/utils.py
+++ b/entity/utils.py
@@ -18,7 +18,7 @@ def batchify(samples, batch_size):
         if len(samples[i]['tokens']) > 350:
             to_single_batch.append(i)
     
-    for i in to_single_batch:
+    for i in to_single_batch[::-1]:
         logger.info('Single batch sample: %s-%d', samples[i]['doc_key'], samples[i]['sentence_ix'])
         list_samples_batches.append([samples[i]])
         samples.remove(samples[i])


### PR DESCRIPTION
The `remove` operations here for python-list is not stable.    
It may cause IndexError when `len(samples) - to_single_batch[-1] > len(to_single_batch)`. 

For example:
```python
samples = ['1', '2', '3', '4', '5']
to_single_batch = [0, 4]
for i in to_single_batch:
    samples.remove(samples[i])
# => IndexError: list index out of range
```