### PR TITLE
Fix taking out long samples

### DIFF
--- a/entity/utils.py
+++ b/entity/utils.py
@@ -18,10 +18,10 @@ def batchify(samples, batch_size):
         if len(samples[i]['tokens']) > 350:
             to_single_batch.append(i)
     
-    for i in to_single_batch[::-1]:
+    for i in to_single_batch:
         logger.info('Single batch sample: %s-%d', samples[i]['doc_key'], samples[i]['sentence_ix'])
         list_samples_batches.append([samples[i]])
-        samples.remove(samples[i])
+    samples = [sample for i, sample in enumerate(samples) if i not in to_single_batch]
 
     for i in range(0, len(samples), batch_size):
         list_samples_batches.append(samples[i:i+batch_size])


### PR DESCRIPTION
Removing long samples from list `samples` in the for loop will change the length and the indices of `samples`. This will cause problems when there are more than one items in `to_single_batch`.

#8 tries to handle the same issue, but it's wrong too, and cannot handle `to_single_batch` longer than 2 items. My fix is to remove long samples after saving all the long samples in `list_samples_batches` list. With this fix, #8 is not necessary.