### PR TITLE
Add auto-populate task labels based on data

### DIFF
--- a/run_entity.py
+++ b/run_entity.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 import numpy as np
 
 from shared.data_structures import Dataset
-from shared.const import task_ner_labels, get_labelmap
+from shared.const import TaskLabels
 from entity.utils import convert_dataset_to_samples, batchify, NpEncoder
 from entity.models import EntityModel
 
@@ -116,7 +116,7 @@ def setseed(seed):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--task', type=str, default=None, required=True, choices=['ace04', 'ace05', 'scierc'])
+    parser.add_argument('--task', type=str, default=None, required=True)
 
     parser.add_argument('--data_dir', type=str, default=None, required=True, 
                         help="path to the preprocessed dataset")
@@ -187,10 +187,11 @@ if __name__ == '__main__':
 
     logger.info(sys.argv)
     logger.info(args)
+
+    task_labels = TaskLabels(args, logger)
+    ner_label2id, ner_id2label = task_labels.get_labelmap()
     
-    ner_label2id, ner_id2label = get_labelmap(task_ner_labels[args.task])
-    
-    num_ner_labels = len(task_ner_labels[args.task]) + 1
+    num_ner_labels = len(task_labels.task_ner_labels[args.task]) + 1
     model = EntityModel(args, num_ner_labels=num_ner_labels)
 
     dev_data = Dataset(args.dev_data)

--- a/run_relation.py
+++ b/run_relation.py
@@ -23,7 +23,7 @@ from transformers import AutoTokenizer
 from transformers import AdamW, get_linear_schedule_with_warmup
 
 from relation.utils import generate_relation_data, decode_sample_id
-from shared.const import task_rel_labels, task_ner_labels
+from shared.const import TaskLabels
 
 CLS = "[CLS]"
 SEP = "[SEP]"
@@ -299,12 +299,14 @@ def main(args):
     logger.info("device: {}, n_gpu: {}".format(
         device, n_gpu))
 
+    task_labels = TaskLabels(args, logger)
+
     # get label_list
     if os.path.exists(os.path.join(args.output_dir, 'label_list.json')):
         with open(os.path.join(args.output_dir, 'label_list.json'), 'r') as f:
             label_list = json.load(f)
     else:
-        label_list = [args.negative_label] + task_rel_labels[args.task]
+        label_list = [args.negative_label] + task_labels.task_rel_labels[args.task]
         with open(os.path.join(args.output_dir, 'label_list.json'), 'w') as f:
             json.dump(label_list, f)
     label2id = {label: i for i, label in enumerate(label_list)}
@@ -313,7 +315,7 @@ def main(args):
 
     tokenizer = AutoTokenizer.from_pretrained(args.model, do_lower_case=args.do_lower_case)
     if args.add_new_tokens:
-        add_marker_tokens(tokenizer, task_ner_labels[args.task])
+        add_marker_tokens(tokenizer, task_labels.task_ner_labels[args.task])
 
     if os.path.exists(os.path.join(args.output_dir, 'special_tokens.json')):
         with open(os.path.join(args.output_dir, 'special_tokens.json'), 'r') as f:
@@ -513,7 +515,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--prediction_file", type=str, default="predictions.json", help="The prediction filename for the relation model")
 
-    parser.add_argument('--task', type=str, default=None, required=True, choices=['ace04', 'ace05', 'scierc'])
+    parser.add_argument('--task', type=str, default=None, required=True)
     parser.add_argument('--context_window', type=int, default=0)
 
     parser.add_argument('--add_new_tokens', action='store_true', 

--- a/run_relation_approx.py
+++ b/run_relation_approx.py
@@ -24,7 +24,7 @@ from transformers import AutoTokenizer
 from transformers import AdamW, get_linear_schedule_with_warmup
 
 from relation.utils import generate_relation_data, decode_sample_id
-from shared.const import task_rel_labels, task_ner_labels
+from shared.const import TaskLabels
 from shared.data_structures import Dataset
 
 CLS = "[CLS]"
@@ -403,12 +403,14 @@ def main(args):
     logger.info("device: {}, n_gpu: {}".format(
         device, n_gpu))
 
+    task_labels = TaskLabels(args, logger)
+
     # get label_list
     if os.path.exists(os.path.join(args.output_dir, 'label_list.json')):
         with open(os.path.join(args.output_dir, 'label_list.json'), 'r') as f:
             label_list = json.load(f)
     else:
-        label_list = [args.negative_label] + task_rel_labels[args.task]
+        label_list = [args.negative_label] + task_labels.task_rel_labels[args.task]
         with open(os.path.join(args.output_dir, 'label_list.json'), 'w') as f:
             json.dump(label_list, f)
     label2id = {label: i for i, label in enumerate(label_list)}
@@ -417,7 +419,7 @@ def main(args):
 
     tokenizer = AutoTokenizer.from_pretrained(args.model, do_lower_case=args.do_lower_case)
     if args.add_new_tokens:
-        add_marker_tokens(tokenizer, task_ner_labels[args.task])
+        add_marker_tokens(tokenizer, task_labels.task_ner_labels[args.task])
 
     if os.path.exists(os.path.join(args.output_dir, 'special_tokens.json')):
         with open(os.path.join(args.output_dir, 'special_tokens.json'), 'r') as f:
@@ -611,7 +613,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--prediction_file", type=str, default="predictions.json", help="The prediction filename for the relation model")
 
-    parser.add_argument('--task', type=str, default=None, required=True, choices=['ace04', 'ace05', 'scierc'])
+    parser.add_argument('--task', type=str, default=None, required=True)
     parser.add_argument('--context_window', type=int, default=0)
 
     parser.add_argument('--add_new_tokens', action='store_true', 

--- a/shared/const.py
+++ b/shared/const.py
@@ -1,25 +1,5 @@
 import json
 
-task_ner_labels = {
-    'ace04': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
-    'ace05': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
-    'scierc': ['Method', 'OtherScientificTerm', 'Task', 'Generic', 'Material', 'Metric'],
-}
-
-task_rel_labels = {
-    'ace04': ['PER-SOC', 'OTHER-AFF', 'ART', 'GPE-AFF', 'EMP-ORG', 'PHYS'],
-    'ace05': ['ART', 'ORG-AFF', 'GEN-AFF', 'PHYS', 'PER-SOC', 'PART-WHOLE'],
-    'scierc': ['PART-OF', 'USED-FOR', 'FEATURE-OF', 'CONJUNCTION', 'EVALUATE-FOR', 'HYPONYM-OF', 'COMPARE'],
-}
-
-def get_labelmap(label_list):
-    label2id = {}
-    id2label = {}
-    for i, label in enumerate(label_list):
-        label2id[label] = i + 1
-        id2label[i + 1] = label
-    return label2id, id2label
-
 class TaskLabels:
     def __init__(self, args, logger):
         self.task_ner_labels = {
@@ -32,31 +12,42 @@ class TaskLabels:
             'ace05': ['ART', 'ORG-AFF', 'GEN-AFF', 'PHYS', 'PER-SOC', 'PART-WHOLE'],
             'scierc': ['PART-OF', 'USED-FOR', 'FEATURE-OF', 'CONJUNCTION', 'EVALUATE-FOR', 'HYPONYM-OF', 'COMPARE'],
         }
+        self.task = args.task
 
-        if args.task not in ['ace04', 'ace05', 'scierc']:
-            self.task_ner_labels[args.task] = set()
-            self.task_rel_labels[args.task] = set()
+        if self.task not in ['ace04', 'ace05', 'scierc']:
+            self.task_ner_labels[self.task] = set()
+            self.task_rel_labels[self.task] = set()
             self._autopopulate_tasks(args)
-            self.task_ner_labels[args.task] = list(self.task_ner_labels[args.task])
-            self.task_rel_labels[args.task] = list(self.task_rel_labels[args.task])
-            logger.info(f'Auto-populating labels for task: {args.task}')
+            self.task_ner_labels[self.task] = list(self.task_ner_labels[self.task])
+            self.task_rel_labels[self.task] = list(self.task_rel_labels[self.task])
+            logger.info(f'Auto-populating labels for task: {self.task}')
         else:
-            logger.info(f'Using pre-loaded labels for task: {args.task}')
-        logger.info('NER Labels: ' + str(self.task_ner_labels[args.task]))
-        logger.info('REL Labels: ' + str(self.task_rel_labels[args.task]))
+            logger.info(f'Using pre-loaded labels for task: {self.task}')
+        logger.info('NER Labels: ' + str(self.task_ner_labels[self.task]))
+        logger.info('REL Labels: ' + str(self.task_rel_labels[self.task]))
 
-    def _get_unique_labels(self, filepath, task):
+    def _get_unique_labels(self, filepath):
         with open(filepath) as f:
             for line in f.readlines():
                 data = json.loads(line.strip())
-                for sentence in data['ner']:
-                    for ner in sentence:
-                        self.task_ner_labels[task].add(ner[2])
-                for sentence in data['relations']:
-                    for rel in sentence:
-                        self.task_rel_labels[task].add(rel[4])
+                if 'ner' in data.keys():
+                    for sentence in data['ner']:
+                        for ner in sentence:
+                            self.task_ner_labels[self.task].add(ner[2])
+                if 'relations' in data.keys():
+                    for sentence in data['relations']:
+                        for rel in sentence:
+                            self.task_rel_labels[self.task].add(rel[4])
 
     def _autopopulate_tasks(self, args):
-        self._get_unique_labels(args.train_data, args.task)
-        self._get_unique_labels(args.dev_data, args.task)
-        self._get_unique_labels(args.test_data, args.task)
+        self._get_unique_labels(args.train_data)
+        self._get_unique_labels(args.dev_data)
+        self._get_unique_labels(args.test_data)
+
+    def get_labelmap(self):
+        label2id = {}
+        id2label = {}
+        for i, label in enumerate(self.task_ner_labels[self.task]):
+            label2id[label] = i + 1
+            id2label[i + 1] = label
+        return label2id, id2label

--- a/shared/const.py
+++ b/shared/const.py
@@ -1,3 +1,5 @@
+import json
+
 task_ner_labels = {
     'ace04': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
     'ace05': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
@@ -17,3 +19,44 @@ def get_labelmap(label_list):
         label2id[label] = i + 1
         id2label[i + 1] = label
     return label2id, id2label
+
+class TaskLabels:
+    def __init__(self, args, logger):
+        self.task_ner_labels = {
+            'ace04': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
+            'ace05': ['FAC', 'WEA', 'LOC', 'VEH', 'GPE', 'ORG', 'PER'],
+            'scierc': ['Method', 'OtherScientificTerm', 'Task', 'Generic', 'Material', 'Metric'],
+        }
+        self.task_rel_labels = {
+            'ace04': ['PER-SOC', 'OTHER-AFF', 'ART', 'GPE-AFF', 'EMP-ORG', 'PHYS'],
+            'ace05': ['ART', 'ORG-AFF', 'GEN-AFF', 'PHYS', 'PER-SOC', 'PART-WHOLE'],
+            'scierc': ['PART-OF', 'USED-FOR', 'FEATURE-OF', 'CONJUNCTION', 'EVALUATE-FOR', 'HYPONYM-OF', 'COMPARE'],
+        }
+
+        if args.task not in ['ace04', 'ace05', 'scierc']:
+            self.task_ner_labels[args.task] = set()
+            self.task_rel_labels[args.task] = set()
+            self._autopopulate_tasks(args)
+            self.task_ner_labels[args.task] = list(self.task_ner_labels[args.task])
+            self.task_rel_labels[args.task] = list(self.task_rel_labels[args.task])
+            logger.info(f'Auto-populating labels for task: {args.task}')
+        else:
+            logger.info(f'Using pre-loaded labels for task: {args.task}')
+        logger.info('NER Labels: ' + str(self.task_ner_labels[args.task]))
+        logger.info('REL Labels: ' + str(self.task_rel_labels[args.task]))
+
+    def _get_unique_labels(self, filepath, task):
+        with open(filepath) as f:
+            for line in f.readlines():
+                data = json.loads(line.strip())
+                for sentence in data['ner']:
+                    for ner in sentence:
+                        self.task_ner_labels[task].add(ner[2])
+                for sentence in data['relations']:
+                    for rel in sentence:
+                        self.task_rel_labels[task].add(rel[4])
+
+    def _autopopulate_tasks(self, args):
+        self._get_unique_labels(args.train_data, args.task)
+        self._get_unique_labels(args.dev_data, args.task)
+        self._get_unique_labels(args.test_data, args.task)


### PR DESCRIPTION
Implemented changes primarily in `shared/const.py` to enable auto-populating NER and REL labels based on data (apart from the standard labels present for `ace04`, `ace05` and `scierc`). Changes include:

- Auto-populating labels when task is not one of the 3 standards *(Removal of choice in task parameter)*
- Storing the new-found labels in output dir at the time of entity model run for relation and relation-approx models
- Converted task labels into a class for better management
- Using the pre-populated labels in case task belongs to one of the 3 standards (for consistent replication of paper results)